### PR TITLE
Fix nightly resolver build and spell checker

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -20,7 +20,8 @@ jobs:
           - {resolver: lts-20.26}
           - {resolver: lts-21.25}
           - {resolver: lts-22.18}
-          - {resolver: nightly}
+          - {resolver: lts-23.5}
+          - {resolver: nightly, stack-yaml: '--stack-yaml=nightly-stack.yaml'}
         exclude:
           - os: macOS-latest
             plan: {resolver: lts-18.28}
@@ -43,8 +44,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.stack
-          key: ${{ runner.os }}-stack-global-${{ matrix.plan.resolver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
+          key: ${{ runner.os }}-stack-global-${{ matrix.plan.resolver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('nightly-stack.yaml') }}-${{ hashFiles('package.yaml') }}
           restore-keys: |
+            ${{ runner.os }}-stack-global-${{ matrix.plan.resolver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('nightly-stack.yaml') }}
             ${{ runner.os }}-stack-global-${{ matrix.plan.resolver }}-${{ hashFiles('stack.yaml') }}
             ${{ runner.os }}-stack-global-${{ matrix.plan.resolver }}
             ${{ runner.os }}-stack-global-
@@ -57,8 +59,9 @@ jobs:
           path: |
               ~\AppData\Roaming\stack
               ~\AppData\Local\Programs\stack
-          key: ${{ runner.os }}-stack-global-${{ matrix.plan.resolver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
+          key: ${{ runner.os }}-stack-global-${{ matrix.plan.resolver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('nightly-stack.yaml') }}-${{ hashFiles('package.yaml') }}
           restore-keys: |
+            ${{ runner.os }}-stack-global-${{ matrix.plan.resolver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('nightly-stack.yaml') }}
             ${{ runner.os }}-stack-global-${{ matrix.plan.resolver }}-${{ hashFiles('stack.yaml') }}
             ${{ runner.os }}-stack-global-${{ matrix.plan.resolver }}
             ${{ runner.os }}-stack-global-
@@ -69,8 +72,10 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .stack-work
-          key: ${{ runner.os }}-stack-work-${{ matrix.plan.resolver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}-${{ hashFiles('**/*.hs') }}
+          key:
+            ${{ runner.os }}-stack-work-${{ matrix.plan.resolver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('nightly-stack.yaml') }}-${{ hashFiles('package.yaml') }}-${{ hashFiles('**/*.hs') }}
           restore-keys: |
+            ${{ runner.os }}-stack-work-${{ matrix.plan.resolver }}-${{ hashFiles('stack.yaml') }}-${{ hashFiles('nightly-stack.yaml') }}
             ${{ runner.os }}-stack-work-${{ matrix.plan.resolver }}-${{ hashFiles('stack.yaml') }}
             ${{ runner.os }}-stack-work-${{ matrix.plan.resolver }}
             ${{ runner.os }}-stack-work-
@@ -85,36 +90,40 @@ jobs:
         run: |
           set -ex
           # shellcheck disable=SC2086
-          stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
+          stack --no-terminal --install-ghc $RES $YML test --bench --only-dependencies
           set +ex
         env:
-          ARGS: "--resolver=${{ matrix.plan.resolver }}"
+          RES: "--resolver=${{ matrix.plan.resolver }}"
+          YML: "${{ matrix.plan.stack-yaml }}"
         if: contains(matrix.os, 'windows') == false
 
       - name: Install dependencies on windows
         shell: powershell
         run: |
-          stack --no-terminal -j 1 --install-ghc ${env:ARGS} test --bench --only-dependencies
+          stack --no-terminal -j 1 --install-ghc ${env:RES} ${env:YML} test --bench --only-dependencies
         env:
-          ARGS: "--resolver=${{ matrix.plan.resolver }}"
+          RES: "--resolver=${{ matrix.plan.resolver }}"
+          YML: "${{ matrix.plan.stack-yaml }}"
         if: contains(matrix.os, 'windows')
 
       - name: Build on unix
         run: |
           set -ex
           # shellcheck disable=SC2086
-          stack --no-terminal --install-ghc test $ARGS --coverage --bench --no-run-benchmarks --haddock --no-haddock-deps
+          stack --no-terminal --install-ghc test $RES $YML --coverage --bench --no-run-benchmarks --haddock --no-haddock-deps
           set +ex
         env:
-          ARGS: "--resolver=${{ matrix.plan.resolver }}"
+          RES: "--resolver=${{ matrix.plan.resolver }}"
+          YML: "${{ matrix.plan.stack-yaml }}"
         if: contains(matrix.os, 'windows') == false
 
       - name: Build on windows
         shell: powershell
         run: |
-          stack --no-terminal --install-ghc test ${env:ARGS} --coverage --bench --no-run-benchmarks --haddock --no-haddock-deps
+          stack --no-terminal --install-ghc test ${env:RES} ${env:YML} --coverage --bench --no-run-benchmarks --haddock --no-haddock-deps
         env:
-          ARGS: "--resolver=${{ matrix.plan.resolver }}"
+          RES: "--resolver=${{ matrix.plan.resolver }}"
+          YML: "${{ matrix.plan.stack-yaml }}"
         if: contains(matrix.os, 'windows')
 
       - name: Cache ~/.stack

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: check-spelling
         id: spelling
-        uses: check-spelling/check-spelling@v0.0.22
+        uses: check-spelling/check-spelling@prerelease
         with:
           suppress_push_for_open_pull_request: ${{ github.actor != 'dependabot[bot]' && 1 }}
           checkout: true

--- a/nightly-stack.yaml
+++ b/nightly-stack.yaml
@@ -1,0 +1,9 @@
+---
+resolver: latest
+packages:
+  - output-blocks
+  - output-blocks-latex
+extra-deps:
+  # temporary replacement of HaTeX until build is fixed for GHC > 9.10.1
+  - git: https://gitlab.com/patritzenfeld/HaTeX.git
+    commit: 1dc649f6030bea2e4259eb5810bf74858efac01a

--- a/output-blocks-latex/src/Control/OutputCapable/Blocks/LaTeX.hs
+++ b/output-blocks-latex/src/Control/OutputCapable/Blocks/LaTeX.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -33,7 +34,12 @@ import Control.OutputCapable.Blocks.Generic (
 
 import Control.Monad.Writer (MonadWriter (tell))
 import Data.Bifunctor (first)
-import Data.Foldable                    (Foldable (foldl'), sequenceA_)
+import Data.Foldable (
+#if !MIN_VERSION_base(4,20,0)
+  Foldable (foldl'),
+#endif
+  sequenceA_,
+  )
 import Data.Text (pack)
 import Text.LaTeX.Base.Syntax (
   LaTeX (TeXComm, TeXEnv, TeXRaw),

--- a/output-blocks/src/Control/OutputCapable/Blocks/Generic.hs
+++ b/output-blocks/src/Control/OutputCapable/Blocks/Generic.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -71,7 +72,13 @@ import Control.Monad.Writer (
   )
 import Data.Bifunctor                   (Bifunctor (second))
 import Data.Kind                        (Type)
-import Data.Foldable                    (foldl', sequenceA_, traverse_)
+import Data.Foldable (
+#if !MIN_VERSION_base(4,20,0)
+  foldl',
+#endif
+  sequenceA_,
+  traverse_,
+  )
 import Data.Functor.Identity            (Identity (Identity))
 import Data.Map                         (Map)
 import Data.Maybe                       (fromMaybe)

--- a/output-blocks/src/Control/OutputCapable/Blocks/Report.hs
+++ b/output-blocks/src/Control/OutputCapable/Blocks/Report.hs
@@ -3,6 +3,7 @@ This module provides a basic 'Language' type and functions for using it
 as well as to this 'Language' specified versions of the generic report
 and output.
 -}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 module Control.OutputCapable.Blocks.Report (
   module GenericReport,
@@ -40,12 +41,13 @@ import qualified Data.Map               as M
 
 import Control.Monad.Identity           (Identity)
 import Control.Monad.State              (State, execState, modify)
+import Data.Data                        (Data)
 import Data.Map                         (Map)
 import Data.Maybe                       (fromMaybe)
 import GHC.Generics                     (Generic)
 
 data Language = English | German
-  deriving (Bounded, Enum, Eq, Generic, Ord, Read, Show)
+  deriving (Bounded, Data, Enum, Eq, Generic, Ord, Read, Show)
 
 type ReportT = GenericReportT Language
 type Out = GenericOut Language


### PR DESCRIPTION
- Provide different `stack.yaml` for nightly-builds
- Add lts-23 build to build and test workflow
- Conditionally exclude `foldl'` import
- Use prerelease spell checker version for `hunspell` support


- Add `Data` instance for `Language`
 
