### PR TITLE
add more specialized version of `getOutputsequenceAndResult`

### DIFF
--- a/output-blocks/src/Control/OutputCapable/Blocks/Type.hs
+++ b/output-blocks/src/Control/OutputCapable/Blocks/Type.hs
@@ -27,6 +27,7 @@ module Control.OutputCapable.Blocks.Type (
   type Output,
   getOutputSequence,
   getOutputSequenceWithRating,
+  getOutputSequenceAndResult,
   toOutputCapable,
   -- ** for 'SpecialOutput'
   type SpecialOutput,
@@ -43,6 +44,7 @@ module Control.OutputCapable.Blocks.Type (
 import qualified Control.OutputCapable.Blocks.Generic.Type as Generic (
   foldMapOutputBy,
   getOutputSequence,
+  getOutputSequenceAndResult,
   getOutputSequenceWithRating,
   inspectTranslations,
   toOutputCapable,
@@ -54,6 +56,7 @@ import qualified Data.Map                         as M (keys)
 import Control.OutputCapable.Blocks.Generic.Type (GenericOutput (..))
 import Control.OutputCapable.Blocks (
   LangM,
+  LangM',
   Language (English),
   OutputCapable,
   Rated,
@@ -85,6 +88,20 @@ getOutputSequenceWithRating
   => Rated (ReportT Output m)
   -> m (Maybe Rational, [Output])
 getOutputSequenceWithRating = Generic.getOutputSequenceWithRating English
+
+{-|
+Converts 'OutputCapable' value using 'GenericOutput'
+into a result and a list of 'GenericOutput'
+
+Consider using 'getOutputSequenceWithRating'
+or even more specific versions of 'Control.OutputCapable.Blocks.Type'
+in order to get better error messages on implementation errors.
+-}
+getOutputSequenceAndResult
+  :: Functor m
+  => LangM' (ReportT Output m) a
+  -> m (Maybe a, [Output])
+getOutputSequenceAndResult = Generic.getOutputSequenceAndResult English
 
 {- |
 Convert a list of 'Output' into any instance of 'OutputCapable'


### PR DESCRIPTION
I'm using the more general version at the moment, but would prefer this to be added for convenience/readability.