### PR TITLE
Extend interface with collapsibles

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -15,5 +15,7 @@ includegraphics
 keepaspectratio
 mconcat
 mempty
+ocg
 snd
+switchocg
 uncurry

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -3,6 +3,7 @@ GADTs
 GHC
 Hspec
 Leijen
+minimisable
 MReport
 TStrict
 concat

--- a/output-blocks-latex/src/Control/OutputCapable/Blocks/LaTeX.hs
+++ b/output-blocks-latex/src/Control/OutputCapable/Blocks/LaTeX.hs
@@ -213,6 +213,7 @@ instance GenericOutputCapable Language (ReportT LaTeX IO) where
     (TeXEnv "itemize" [] . foldr (\x y -> TeXComm "item" [] <> x <> y) mempty)
     . sequenceA_
   latex = format . TeXRaw . pack . ('$':) . (++ "$")
+  folding _ t c = translated t *> format par *> indent c
   code = format . TeXEnv "verbatim" [] . TeXRaw . pack
   translatedCode lm = LangM
     $ Report . tell . (:[]) . Localised

--- a/output-blocks-latex/src/Control/OutputCapable/Blocks/LaTeX.hs
+++ b/output-blocks-latex/src/Control/OutputCapable/Blocks/LaTeX.hs
@@ -213,7 +213,7 @@ instance GenericOutputCapable Language (ReportT LaTeX IO) where
     (TeXEnv "itemize" [] . foldr (\x y -> TeXComm "item" [] <> x <> y) mempty)
     . sequenceA_
   latex = format . TeXRaw . pack . ('$':) . (++ "$")
-  folding _ t c = translated t *> format par *> indent c
+  folded _ t c = translated t *> format par *> indent c
   code = format . TeXEnv "verbatim" [] . TeXRaw . pack
   translatedCode lm = LangM
     $ Report . tell . (:[]) . Localised

--- a/output-blocks/src/Control/OutputCapable/Blocks.hs
+++ b/output-blocks/src/Control/OutputCapable/Blocks.hs
@@ -508,7 +508,12 @@ This is a specified version of 'Generic.collapsible'
 which enforces the usage pattern.
 You should always prefer this specified version over the generic.
 -}
-collapsed :: GenericOutputCapable l m => Bool -> State (Map l String) () -> GenericLangM l m () -> GenericLangM l m ()
+collapsed
+  :: GenericOutputCapable l m
+  => Bool
+  -> State (Map l String) ()
+  -> GenericLangM l m ()
+  -> GenericLangM l m ()
 collapsed = Generic.collapsed
 
 {-|

--- a/output-blocks/src/Control/OutputCapable/Blocks.hs
+++ b/output-blocks/src/Control/OutputCapable/Blocks.hs
@@ -504,7 +504,7 @@ translations :: State (Map l a) () -> Map l a
 translations = Generic.translations
 
 {-|
-This is a specified version of 'Generic.collapsible'
+This is a specified version of 'Generic.collapsed'
 which enforces the usage pattern.
 You should always prefer this specified version over the generic.
 -}

--- a/output-blocks/src/Control/OutputCapable/Blocks.hs
+++ b/output-blocks/src/Control/OutputCapable/Blocks.hs
@@ -42,6 +42,7 @@ module Control.OutputCapable.Blocks (
   toAbort,
   -- * Translation
   ArticleToUse (..),
+  collapsible,
   english,
   german,
   localise,
@@ -71,6 +72,7 @@ module Control.OutputCapable.Blocks (
 
 import qualified Control.OutputCapable.Blocks.Generic as Generic (
   alignOutput,
+  collapsible,
   combineReports,
   combineTwoReports,
   toAbort,
@@ -502,6 +504,14 @@ translations :: State (Map l a) () -> Map l a
 translations = Generic.translations
 
 {-|
+This is a specified version of 'Generic.collapsible'
+which enforces the usage pattern.
+You should always prefer this specified version over the generic.
+-}
+collapsible :: GenericOutputCapable l m => Bool -> State (Map l String) () -> GenericLangM l m () -> GenericLangM l m ()
+collapsible = Generic.collapsible
+
+{-|
 Provide an English translation
 to be appended after previous English translations.
 -}
@@ -556,6 +566,12 @@ instance (l ~ Language)
     pure ()
   refuse        = toAbort
   latex         = format . putStrLn . ("LaTeX: " ++)
+  folding b t c = do
+    format $ putStr $ "(" ++ (if b then "-" else "+") ++ ") "
+    translated t
+    format $ putStrLn ""
+    when b (indent c)
+    pure ()
   code          = format . putStr . (\xs -> " <" ++ xs ++ "> ")
   translatedCode lm =
     out (Localised $ putStr . (\xs -> " <" ++ xs ++ "> ") . lm)

--- a/output-blocks/src/Control/OutputCapable/Blocks.hs
+++ b/output-blocks/src/Control/OutputCapable/Blocks.hs
@@ -42,7 +42,7 @@ module Control.OutputCapable.Blocks (
   toAbort,
   -- * Translation
   ArticleToUse (..),
-  collapsible,
+  collapsed,
   english,
   german,
   localise,
@@ -72,7 +72,7 @@ module Control.OutputCapable.Blocks (
 
 import qualified Control.OutputCapable.Blocks.Generic as Generic (
   alignOutput,
-  collapsible,
+  collapsed,
   combineReports,
   combineTwoReports,
   toAbort,
@@ -508,8 +508,8 @@ This is a specified version of 'Generic.collapsible'
 which enforces the usage pattern.
 You should always prefer this specified version over the generic.
 -}
-collapsible :: GenericOutputCapable l m => Bool -> State (Map l String) () -> GenericLangM l m () -> GenericLangM l m ()
-collapsible = Generic.collapsible
+collapsed :: GenericOutputCapable l m => Bool -> State (Map l String) () -> GenericLangM l m () -> GenericLangM l m ()
+collapsed = Generic.collapsed
 
 {-|
 Provide an English translation
@@ -566,11 +566,11 @@ instance (l ~ Language)
     pure ()
   refuse        = toAbort
   latex         = format . putStrLn . ("LaTeX: " ++)
-  folding b t c = do
-    format $ putStr $ "(" ++ (if b then "-" else "+") ++ ") "
+  folded b t c = do
+    format $ putStr $ "(" ++ (if b then "+" else "-") ++ ") "
     translated t
     format $ putStrLn ""
-    when b (indent c)
+    unless b (indent c)
     pure ()
   code          = format . putStr . (\xs -> " <" ++ xs ++ "> ")
   translatedCode lm =

--- a/output-blocks/src/Control/OutputCapable/Blocks/Generic.hs
+++ b/output-blocks/src/Control/OutputCapable/Blocks/Generic.hs
@@ -37,7 +37,7 @@ module Control.OutputCapable.Blocks.Generic (
   ($=<<),
   ($>>),
   ($>>=),
-  collapsible,
+  collapsed,
   evalLangM,
   execLangM,
   runLangMReport,
@@ -117,7 +117,7 @@ class (Applicative m, Ord l) => GenericOutputCapable l m where
   -- | for LaTeX-Math code (i.e. without surrounding @$@)
   latex      :: String -> GenericLangM l m ()
   -- | for minimisable output with a default state (open/closed) and title
-  folding :: Bool -> (l -> String) -> GenericLangM l m () -> GenericLangM l m ()
+  folded :: Bool -> (l -> String) -> GenericLangM l m () -> GenericLangM l m ()
   -- | for fixed width fonts (i.e. typewriter style)
   code       :: String -> GenericLangM l m ()
   code = translatedCode . const
@@ -267,7 +267,7 @@ instance Ord l => GenericOutputCapable l Maybe where
   itemizeM        = sequenceA_
   indent xs       = xs
   latex _         = pure ()
-  folding _ _ _ = pure ()
+  folded _ _ _ = pure ()
   code _          = pure ()
   translatedCode _ = pure ()
   translated _    = pure ()
@@ -295,13 +295,13 @@ translations = flip execState M.empty
 mapToMatching :: Ord language => Map language String -> language -> String
 mapToMatching l = fromMaybe "" . flip M.lookup l
 
-collapsible
+collapsed
   :: GenericOutputCapable language m
   => Bool
   -> State (Map language String) a1
   -> GenericLangM language m ()
   -> GenericLangM language m ()
-collapsible b t = folding b (mapToMatching $ translations t)
+collapsed b t = folded b (mapToMatching $ translations t)
 
 {-|
 Provided a neutral element and a function to combine generated output

--- a/output-blocks/src/Control/OutputCapable/Blocks/Generic/Type.hs
+++ b/output-blocks/src/Control/OutputCapable/Blocks/Generic/Type.hs
@@ -24,7 +24,7 @@ import Control.OutputCapable.Blocks.Generic (
   GenericOutputCapable (..),
   GenericReportT,
   alignOutput,
-  collapsible,
+  collapsed,
   combineReports,
   combineTwoReports,
   format,
@@ -64,7 +64,7 @@ data GenericOutput language element
     -- ^ for indenting output
     | Latex String
     -- ^ latex code (for formulas and text blocks only)
-    | Folding Bool (Map language String) [GenericOutput language element]
+    | Folded Bool (Map language String) [GenericOutput language element]
     -- ^ minimisable output with default open-state, title and content
     | Code (Map language String)
     -- ^ to output as text with fixed width, providing translations
@@ -113,7 +113,7 @@ instance
 
   latex = format . Latex
 
-  folding b t = alignOutput (Folding b $ toMap t)
+  folded b t = alignOutput (Folded b $ toMap t)
 
   translatedCode =  format . Code . toMap
 
@@ -141,7 +141,7 @@ toOutputCapable toOutputPart yesNoDisplay parts = for_ parts toInterface
       Itemized xs      -> itemizeM $ map toOutputCapable' xs
       Indented xs      -> indent $ toOutputCapable' xs
       Latex s          -> latex s
-      Folding b t c    -> collapsible b (put t) $ toOutputCapable' c
+      Folded b t c     -> collapsed b (put t) $ toOutputCapable' c
       Code m           -> translateCode $ put m
       Translated m     -> translate $ put m
       Special element  -> toOutputPart element
@@ -222,7 +222,7 @@ foldMapOutputBy f evaluate x = case x of
   Itemized xs       -> foldr (flip (foldr (f . descend))) (evaluate x) xs
   Indented xs       -> foldr (f . descend) (evaluate x) xs
   Latex {}          -> evaluate x
-  Folding _ _ xs    -> foldr (f . descend) (evaluate x) xs
+  Folded _ _ xs     -> foldr (f . descend) (evaluate x) xs
   Code {}           -> evaluate x
   Translated {}     -> evaluate x
   Special {}        -> evaluate x
@@ -250,7 +250,7 @@ inspectTranslations inspectSpecial inspectTranslation f z = foldMapOutputBy f $ 
   Itemized {}       -> z
   Indented {}       -> z
   Latex {}          -> z
-  Folding _ t _     -> inspectTranslation t
+  Folded _ t _      -> inspectTranslation t
   Code ts           -> inspectTranslation ts
   Translated ts     -> inspectTranslation ts
   Special element   -> inspectSpecial element

--- a/output-blocks/src/Control/OutputCapable/Blocks/Type.hs
+++ b/output-blocks/src/Control/OutputCapable/Blocks/Type.hs
@@ -18,6 +18,7 @@ module Control.OutputCapable.Blocks.Type (
   pattern Itemized,
   pattern Indented,
   pattern Latex,
+  pattern Folded,
   pattern Code,
   pattern Translated,
   pattern Special,

--- a/output-blocks/test/Control/OutputCapable/Blocks/Generic/TypeSpec.hs
+++ b/output-blocks/test/Control/OutputCapable/Blocks/Generic/TypeSpec.hs
@@ -38,7 +38,7 @@ instance {-# Overlapping #-} Arbitrary (Map Language String) where
 
 instance Arbitrary (GenericOutput Language ()) where
   arbitrary = genericArbitrary'
-    $ 1 % 1 % 1 % 1 % 1 % 1 % 1 % 1 % 1 % 1 % (0 :: W "Special") % ()
+    $ 1 % 1 % 1 % 1 % 1 % 1 % 1 % 1 % 1 % 1 % 1 % (0 :: W "Special") % ()
 
 
 


### PR DESCRIPTION
In tandem with the proposed change to `Output` in Autotool. I tried to stick to the design of the other provided primitives.

- new function in `GenericOutputCapable` interface `folding`
- Params: `Bool` for initial state, `(l -> String)` for the title,  `GenericLangM` for content
- `collapsible` function for actual use, similar to `translate`/`translations` and `translated` to make language input easier
- more specific versions in OutputCapable.Blocks
- Algebraic Datatype extended to include this element

I'd like to discuss how to define `folding` for the "latex instance" in this repo. It's actually [possible to add extendable sections to a pdf file](https://i.sstatic.net/oxMNI.gif), but the space is still left blank, even if the content is hidden. So it seems to be rather useless. 
